### PR TITLE
Adding a template for release retrospective issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/retrospectives.md
+++ b/.github/ISSUE_TEMPLATE/retrospectives.md
@@ -1,0 +1,30 @@
+---
+name: Retrospectives
+about: Retrospective Template
+title: 'Retrospective for <month> <year> Releases'
+labels: Retrospective
+assignees: ''
+
+---
+
+This will be a Slack call after the release, with at least a week of notice in the #Release Slack channel.
+
+A bulleted list of all proposed agenda items in this issue (whether at the top or in a comment) will be created on the day of the call, with a list of actions added at the end.
+
+Invited: Everyone.
+
+Retrospective Owner Tasks (in order):
+- [ ] Post this issue's URL on the \#Release Slack channel around the start of the new release.
+- [ ] Copy actions from the previous retrospective into this issue, while ignoring actions that have an issue link (i.e. clearly-completed actions).
+- [ ] Wait until all builds have been released, with no clear signs of additional respins.
+- [ ] Announce the retrospective Slack call's date + time on \#Release at least one full week in advance, and send out meeting invites.
+- [ ] On the day of the call, compile all of the agenda items into a tick-box list inside a single comment.
+- [ ] Host the slack call for the retrospective, including:
+  - [ ] Iterating over the actions from the previous retrospective issue, annotating *both* issues with any issues that have been raised for them.
+  - [ ] Iterate over the agenda tick-list, ensuring everything gets debated.
+  - [ ] Create a clear list of actions at the end of the retrospective, including volunteer names.
+- [ ] Close the issue for the previous retrospective, ensuring that every action is annotated with its conclusion (issue link, ignored, etc).
+- [ ] Create a new retrospective issue for the next release.
+- [ ] Set yourself a calendar reminder so that you remember to commence step 1 (in the new issue) just before the next release.
+
+Add proposed agenda items as comments below.


### PR DESCRIPTION
This template ensures all the necessary prep is done for the
retrospective, that people are aware of the retrospective, and that
a new issue is created for the next one.

Signed-off-by: Adam Farley <adfarley@redhat.com>