### PR TITLE
Remove Google doc references from the retrospective template

### DIFF
--- a/.github/ISSUE_TEMPLATE/retrospectives.md
+++ b/.github/ISSUE_TEMPLATE/retrospectives.md
@@ -11,11 +11,11 @@ assignees: ''
 
 A retrospective for all efforts surrounding the titular releases. 
 
-All community members are welcome to contribute to the agenda via comments in the [linked Google Document](https://docs.google.com/document/d/1JPIvjl__YJbMpSYyKND1s-rPVOlS_V1k3vzooTIDaNs/edit?usp=sharing).
+All community members are welcome to contribute to the agenda via comments below.
 
 This will be a virtual meeting after the release, with at least a week of notice in the #release Slack channel.
 
-On the day of the meeting the agenda items in the Google Document will be iterated over, with a list of actions added at the end.
+On the day of the meeting the agenda items will be iterated over, with a list of actions added in a comment at/near the end.
 
 Invited: Everyone.
 
@@ -41,9 +41,5 @@ Retrospective Owner Tasks (in order):
   - [ ] Iterate over the agenda, ensuring everything gets debated.
   - [ ] Create a clear list of actions at the end of the retrospective, including volunteer names.
 - [ ] Create a new retrospective issue for the next release.
-- [ ] Copy the \"Next Retrospective\" Google document into the relevant subfolder and rename it appropriately.
-- [ ] Empty the Retrospective_Next Google document (except for the actions, which should be starred), and change the month at the top to the next release month.
 - [ ] Set yourself a calendar reminder so that you remember to commence step 1 (in the new issue) just before the next release.
 - [ ] Close this issue.
-
-Add proposed agenda items to [this Google Document](https://docs.google.com/document/d/1JPIvjl__YJbMpSYyKND1s-rPVOlS_V1k3vzooTIDaNs/edit?usp=sharing).


### PR DESCRIPTION
Ultimately, we need to create issues for retrospectives, and having
the Google doc meant that people would get confused and add agenda
idems to one, the other, or both. For simplicity, the recent
retrospective meeting elected to cut out the Google doc.

Signed-off-by: Adam Farley <adfarley@redhat.com>