### PR TITLE
Update status icons in release status template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-status.md
+++ b/.github/ISSUE_TEMPLATE/release-status.md
@@ -9,9 +9,12 @@ assignees: ''
 
 Sharing information in this issue since the TCK work is being tracked in temurin-compliance private repo not visible to the community (as per the OCTLA).  Risks and expectations for timing on the release are listed in this [issue comment](https://github.com/adoptium/adoptium/issues/3#issuecomment-866903922).  Primary platforms (x64 Linux/Windows/OSX) in **bold** are prioritized, secondary platforms not in bold follow in no particular order (as machine resources are available).
 
-✅ results in these Tables means the activity has successfully completed.
+✔️ results in these Tables means the activity has successfully completed.
+
 ⏳ results means that we are actively working on closing off the runs needed for this version, platform, binaryType.
+
 ⛔ means there is no build planned for that version/platform combination.
+
 ⏸️ means activity not yet started.
 
 ### JDK8uXXX-bXX

--- a/.github/ISSUE_TEMPLATE/release-status.md
+++ b/.github/ISSUE_TEMPLATE/release-status.md
@@ -9,51 +9,66 @@ assignees: ''
 
 Sharing information in this issue since the TCK work is being tracked in temurin-compliance private repo not visible to the community (as per the OCTLA).  Risks and expectations for timing on the release are listed in this [issue comment](https://github.com/adoptium/adoptium/issues/3#issuecomment-866903922).  Primary platforms (x64 Linux/Windows/OSX) in **bold** are prioritized, secondary platforms not in bold follow in no particular order (as machine resources are available).
 
-👍 results in these Tables means the activity has successfully completed.
+✅ results in these Tables means the activity has successfully completed.
 ⏳ results means that we are actively working on closing off the runs needed for this version, platform, binaryType.
 ⛔ means there is no build planned for that version/platform combination.
-📂 means activity not yet started.
+⏸️ means activity not yet started.
 
-### JDK8u322
-| Platform | jdk8 AQA  | jdk8 TCK | jdk8 installers | jdk8 containers | Notes |
-| -----  | ----- | ----- | ----- | ----- | ----- |
-| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/linux/x64/hotspot) | 📂 | 📂 | 📂 | 📂 |   |
-| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/windows/x64/hotspot) | 📂 | 📂 | 📂 | 📂 |   |
-| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/mac/x64/hotspot) | 📂 | 📂 | 📂 | ⛔ |   |
-| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/linux/aarch64/hotspot) | 📂  | 📂 | 📂 | 📂 |   |
-| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/linux/ppc64le/hotspot) | 📂 | 📂 | 📂 | 📂 |   |
-| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/aix/ppc64/hotspot) | 📂 | 📂 | ⛔ | ⛔ |   |
-| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/windows/x86-32/hotspot) | 📂 | 📂 | 📂 | ⛔ |   |
-| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/yyyy/artifact/target/linux/arm/hotspot) | 📂 | 📂 | 📂 | 📂 |   |
-| [sparcv9 solaris](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/solaris/sparcv9/hotspot) | 📂 | 📂 | ⛔  | ⛔ |   |
-| [x86 solaris](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/solaris/x64/hotspot) |  📂   | 📂   | ⛔  | ⛔ |  |
+### JDK8uXXX-bXX
+| Platform | jdk8 AQA  | jdk8 TCK | jdk8 installers | jdk8 containers | jdk8 published | Notes |
+| -----  | ----- | ----- | ----- | ----- | ----- | ----- |
+| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/linux/x64/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/windows/x64/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/mac/x64/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/linux/aarch64/hotspot) | ⏸️  | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/linux/ppc64le/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/aix/ppc64/hotspot) | ⏸️ | ⏸️ | ⛔ | ⛔ |  |  |
+| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/windows/x86-32/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/yyyy/artifact/target/linux/arm/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [sparcv9 solaris](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/solaris/sparcv9/hotspot) | ⏸️ | ⏸️ | ⛔  | ⛔ |  |  |
+| [x86 solaris](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/solaris/x64/hotspot) |  ⏸️   | ⏸️   | ⛔  | ⛔ |  |  |
 
-### JDK11.0.14
-| Platform  | jdk11 AQA  | jdk11 TCK | jdk11 installers | jdk11 containers | Notes |
-| ----- | ----- | ----- | ----- | ----- | ----- |
-| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/x64/hotspot/) | 📂 | 📂 | 📂 | 📂 |   |
-| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/windows/x64/hotspot/) | 📂 | 📂 | 📂 | 📂 |   |
-| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/mac/x64/hotspot/) | 📂 | 📂 | 📂 | ⛔ |   |
-| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/aarch64/hotspot/) | 📂 | 📂 | 📂 | 📂 |   |
-| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/ppc64le/hotspot/) |  📂 | 📂 | 📂 | 📂 |   |
-| [s390x Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/s390x/hotspot/) | 📂 | 📂 | 📂 | 📂 |   |
-| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/aix/ppc64/hotspot/) | 📂 | 📂 | ⛔ |⛔ |   |
-| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/windows/x86-32/hotspot/) | 📂 | 📂 | 📂 | ⛔ |   |
-| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/arm/hotspot/) | 📂 | 📂 | 📂 | 📂 |   |
-| [x64 alpine-Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/alpine-linux/x64/hotspot/) | 📂 | 📂 | 📂 | 📂 |  This will be a headless build |
-| [aarch64 Mac](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxxx/artifact/target/mac/aarch64/hotspot/) | 📂 | 📂 | 📂 | ⛔ |   |
+### JDK11.0.XX+Y
+| Platform  | jdk11 AQA  | jdk11 TCK | jdk11 installers | jdk11 containers | jdk11 published | Notes |
+| ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/windows/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/mac/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/ppc64le/hotspot/) |  ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [s390x Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/s390x/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/aix/ppc64/hotspot/) | ⏸️ | ⏸️ | ⛔ |⛔ |  |  |
+| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/windows/x86-32/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/arm/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [x64 alpine-Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/alpine-linux/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
+| [aarch64 Mac](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxxx/artifact/target/mac/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
 
-### JDK17.0.2
-| Platforms  | jdk17 AQA  | jdk17 TCK | jdk17 installers | jdk17 containers | Notes |
-| ----- | ----- | ----- | ----- | ----- | ----- |
-| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/x64/hotspot/)| 📂 | 📂 | 📂 | 📂 |   |
-| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/windows/x64/hotspot/) | 📂 | 📂 | 📂  | 📂  |   |
-| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/mac/x64/hotspot/) | 📂 | 📂 | 📂  | ⛔ |   |
-| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/aarch64/hotspot/) | 📂 | 📂 | 📂 | 📂 |   |
-| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/ppc64le/hotspot/) | 📂 | 📂 | 📂 | 📂 |   |
-| [s390x Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/s390x/hotspot/) | 📂 | 📂 | 📂 | 📂 |   |
-| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/aix/ppc64/hotspot/)| 📂 | 📂 | ⛔ |⛔  |   |
-| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/windows/x86-32/hotspot/) | 📂 | 📂 | 📂 | ⛔ |   |
-| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/arm/hotspot/) | 📂 | 📂 | 📂 | 📂 |   |
-| [x64 alpine-Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/alpine-linux/x64/hotspot/) | 📂 | 📂 | 📂 | 📂 | This will be a headless build |
-| [aarch64 Mac](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/mac/aarch64/hotspot/) | 📂 | 📂 | 📂 | ⛔ |   |
+### JDK17.0.XX+Y
+| Platforms  | jdk17 AQA  | jdk17 TCK | jdk17 installers | jdk17 containers | jdk17 published | Notes |
+| ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/x64/hotspot/)| ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/windows/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️  | ⏸️  |  |  |
+| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/mac/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️  | ⛔ |  |  |
+| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/ppc64le/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [s390x Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/s390x/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/aix/ppc64/hotspot/)| ⏸️ | ⏸️ | ⛔ |⛔  |  |  |
+| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/windows/x86-32/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/arm/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [x64 alpine-Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/alpine-linux/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
+| [aarch64 Mac](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/mac/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+
+### JDK18.0.XX+Y
+| Platforms  | jdk18 AQA  | jdk18 TCK | jdk18 installers | jdk18 containers | jdk18 published | Notes |
+| ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/x64/hotspot/)| ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/windows/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️  | ⏸️  |  |  |
+| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/mac/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️  | ⛔ |  |  |
+| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/ppc64le/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [s390x Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/s390x/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/aix/ppc64/hotspot/)| ⏸️ | ⏸️ | ⛔ |⛔  |  |  |
+| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/windows/x86-32/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/arm/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| [x64 alpine-Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/alpine-linux/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
+| [aarch64 Mac](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/mac/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |

--- a/.github/ISSUE_TEMPLATE/release-status.md
+++ b/.github/ISSUE_TEMPLATE/release-status.md
@@ -18,60 +18,60 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 ⏸️ means activity not yet started.
 
 ### JDK8uXXX-bXX
-| Platform | jdk8 AQA  | jdk8 TCK | jdk8 installers | jdk8 containers | jdk8 published | Notes |
+| Platform | jdk8 AQA | jdk8 TCK | jdk8 installers | jdk8 containers | jdk8 published | Notes |
 | -----  | ----- | ----- | ----- | ----- | ----- | ----- |
-| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/linux/x64/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/windows/x64/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/mac/x64/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
-| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/linux/aarch64/hotspot) | ⏸️  | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/linux/ppc64le/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/aix/ppc64/hotspot) | ⏸️ | ⏸️ | ⛔ | ⛔ |  |  |
-| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/windows/x86-32/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
-| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/yyyy/artifact/target/linux/arm/hotspot) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [sparcv9 solaris](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/solaris/sparcv9/hotspot) | ⏸️ | ⏸️ | ⛔  | ⛔ |  |  |
-| [x86 solaris](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/xxxx/artifact/target/solaris/x64/hotspot) |  ⏸️   | ⏸️   | ⛔  | ⛔ |  |  |
+| **x64 Linux** | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| **x64 Windows** | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| **x64 Mac** | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| aarch64 Linux | ⏸️  | ⏸️ | ⏸️ | ⏸️ |  |  |
+| ppcle64 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| ppc64 AIX | ⏸️ | ⏸️ | ⛔ | ⛔ |  |  |
+| x32 Windows | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| arm32 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| sparcv9 solaris | ⏸️ | ⏸️ | ⛔  | ⛔ |  |  |
+| x86 solaris |  ⏸️   | ⏸️   | ⛔  | ⛔ |  |  |
 
 ### JDK11.0.XX+Y
-| Platform  | jdk11 AQA  | jdk11 TCK | jdk11 installers | jdk11 containers | jdk11 published | Notes |
+| Platform | jdk11 AQA | jdk11 TCK | jdk11 installers | jdk11 containers | jdk11 published | Notes |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
-| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/windows/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/mac/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
-| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/ppc64le/hotspot/) |  ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [s390x Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/s390x/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/aix/ppc64/hotspot/) | ⏸️ | ⏸️ | ⛔ |⛔ |  |  |
-| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/windows/x86-32/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
-| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/linux/arm/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [x64 alpine-Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk11-pipeline/xxxx/artifact/target/alpine-linux/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
-| [aarch64 Mac](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxxx/artifact/target/mac/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| **x64 Linux** | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| **x64 Windows** | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| **x64 Mac** | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| aarch64 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| ppcle64 Linux |  ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| s390x Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| ppc64 AIX | ⏸️ | ⏸️ | ⛔ |⛔ |  |  |
+| x32 Windows | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| arm32 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| x64 alpine-Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
+| aarch64 Mac | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
 
 ### JDK17.0.XX+Y
-| Platforms  | jdk17 AQA  | jdk17 TCK | jdk17 installers | jdk17 containers | jdk17 published | Notes |
+| Platforms | jdk17 AQA | jdk17 TCK | jdk17 installers | jdk17 containers | jdk17 published | Notes |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
-| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/x64/hotspot/)| ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/windows/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️  | ⏸️  |  |  |
-| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/mac/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️  | ⛔ |  |  |
-| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/ppc64le/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [s390x Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/s390x/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/aix/ppc64/hotspot/)| ⏸️ | ⏸️ | ⛔ |⛔  |  |  |
-| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/windows/x86-32/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
-| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/linux/arm/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [x64 alpine-Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/alpine-linux/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
-| [aarch64 Mac](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk17-pipeline/xxx/artifact/target/mac/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| **x64 Linux**| ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| **x64 Windows** | ⏸️ | ⏸️ | ⏸️  | ⏸️  |  |  |
+| **x64 Mac** | ⏸️ | ⏸️ | ⏸️  | ⛔ |  |  |
+| aarch64 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| ppcle64 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| s390x Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| ppc64 AIX| ⏸️ | ⏸️ | ⛔ |⛔  |  |  |
+| x32 Windows | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| arm32 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| x64 alpine-Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
+| aarch64 Mac | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
 
 ### JDK18.0.XX+Y
-| Platforms  | jdk18 AQA  | jdk18 TCK | jdk18 installers | jdk18 containers | jdk18 published | Notes |
+| Platform | jdk18 AQA | jdk18 TCK | jdk18 installers | jdk18 containers | jdk18 published | Notes |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
-| [**x64 Linux**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/x64/hotspot/)| ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [**x64 Windows**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/windows/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️  | ⏸️  |  |  |
-| [**x64 Mac**](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/mac/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️  | ⛔ |  |  |
-| [aarch64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [ppcle64 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/ppc64le/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [s390x Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/s390x/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [ppc64 AIX](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/aix/ppc64/hotspot/)| ⏸️ | ⏸️ | ⛔ |⛔  |  |  |
-| [x32 Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/windows/x86-32/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
-| [arm32 Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/linux/arm/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
-| [x64 alpine-Linux](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/alpine-linux/x64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
-| [aarch64 Mac](https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk18-pipeline/xxx/artifact/target/mac/aarch64/hotspot/) | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| **x64 Linux**| ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| **x64 Windows** | ⏸️ | ⏸️ | ⏸️  | ⏸️  |  |  |
+| **x64 Mac** | ⏸️ | ⏸️ | ⏸️  | ⛔ |  |  |
+| aarch64 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| ppcle64 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| s390x Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| ppc64 AIX| ⏸️ | ⏸️ | ⛔ |⛔  |  |  |
+| x32 Windows | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
+| arm32 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| x64 alpine-Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
+| aarch64 Mac | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |


### PR DESCRIPTION
This updates the icons used for 'not started', 'in progress' and 'complete' in accordance with some [suggestions I had in a previous retrospective](https://github.com/adoptium/adoptium/issues/104#issuecomment-1017747613) but hadn't yet got round to implementing.

The comment in https://github.com/adoptium/adoptium/issues/140#issuecomment-1104733897 which has received 49 👍🏻 against it at the time of creating this PR would seem to suggest there is considerable support for this.

I've been in two minds about whether to use ✔️ or ✅ for the 'complete' symbol. I've gone with the former because it comes out as green in the rendered markdown so is more distinctive. Comments welcome.

This also adds the 'published' column to the table - initially empty. I guess we could add in a paused symbol before it's complete but my gut feel is that it's an important column which is more clearly defined when it's blank or ticked ...