### PR TITLE
chore: update release status table

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-status.md
+++ b/.github/ISSUE_TEMPLATE/release-status.md
@@ -18,7 +18,7 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 ⏸️ means activity not yet started.
 
 ### JDK8uXXX-bXX
-| Platform | jdk8 AQA | jdk8 TCK | jdk8 installers | jdk8 containers | jdk8 published | Notes |
+| Platform | jdk8 AQA | jdk8 TCK | jdk8 installers | jdk8 images | jdk8 published | Notes |
 | -----  | ----- | ----- | ----- | ----- | ----- | ----- |
 | **x64 Linux** | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
 | **x64 Windows** | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
@@ -28,11 +28,12 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 | ppc64 AIX | ⏸️ | ⏸️ | ⛔ | ⛔ |  |  |
 | x32 Windows | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
 | arm32 Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
+| x64 alpine-Linux | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  | This will be a headless build |
 | sparcv9 solaris | ⏸️ | ⏸️ | ⛔  | ⛔ |  |  |
 | x86 solaris |  ⏸️   | ⏸️   | ⛔  | ⛔ |  |  |
 
 ### JDK11.0.XX+Y
-| Platform | jdk11 AQA | jdk11 TCK | jdk11 installers | jdk11 containers | jdk11 published | Notes |
+| Platform | jdk11 AQA | jdk11 TCK | jdk11 installers | jdk11 images | jdk11 published | Notes |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
 | **x64 Linux** | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
 | **x64 Windows** | ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
@@ -47,7 +48,7 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 | aarch64 Mac | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
 
 ### JDK17.0.XX+Y
-| Platforms | jdk17 AQA | jdk17 TCK | jdk17 installers | jdk17 containers | jdk17 published | Notes |
+| Platforms | jdk17 AQA | jdk17 TCK | jdk17 installers | jdk17 images | jdk17 published | Notes |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
 | **x64 Linux**| ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
 | **x64 Windows** | ⏸️ | ⏸️ | ⏸️  | ⏸️  |  |  |
@@ -62,7 +63,7 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 | aarch64 Mac | ⏸️ | ⏸️ | ⏸️ | ⛔ |  |  |
 
 ### JDK18.0.XX+Y
-| Platform | jdk18 AQA | jdk18 TCK | jdk18 installers | jdk18 containers | jdk18 published | Notes |
+| Platform | jdk18 AQA | jdk18 TCK | jdk18 installers | jdk18 images | jdk18 published | Notes |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
 | **x64 Linux**| ⏸️ | ⏸️ | ⏸️ | ⏸️ |  |  |
 | **x64 Windows** | ⏸️ | ⏸️ | ⏸️  | ⏸️  |  |  |


### PR DESCRIPTION
	- change "containers" to "image", from https://github.com/adoptium/adoptium/issues/153#issuecomment-1193926916
	- add missing x64 alpine-linux for jdk8 from  https://github.com/adoptium/adoptium/issues/153#issuecomment-1207432143