### PR TITLE
Update tables with the extra primary platforms

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-status.md
+++ b/.github/ISSUE_TEMPLATE/release-status.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Sharing information in this issue since the TCK work is being tracked in temurin-compliance private repo not visible to the community (as per the OCTLA).  Risks and expectations for timing on the release are listed in this [issue comment](https://github.com/adoptium/adoptium/issues/3#issuecomment-866903922).  Primary platforms (x64 Linux/Windows/OSX) in **bold** are prioritized, secondary platforms not in bold follow in no particular order (as machine resources are available).
+Sharing information in this issue since the TCK work is being tracked in temurin-compliance private repo not visible to the community (as per the OCTLA).  Risks and expectations for timing on the release are listed in this [issue comment](https://github.com/adoptium/adoptium/issues/3#issuecomment-866903922).  Primary platforms (x64 Linux/Windows/OSX and aarch64 Linux/OSX) in **bold** are prioritized, secondary platforms not in bold follow in no particular order (as machine resources are available).  We retrospectively measure and track how well we do against these targets in these [Adoptium Release Scorecards](https://github.com/adoptium/adoptium/wiki/Adoptium-Release-Scorecards) in order to continuously assess and improve.
 
 ✔️ results in these Tables means the activity has successfully completed.
 
@@ -23,7 +23,7 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 | **x64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | **x64 Windows** | ⏸️   | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | **x64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
-| aarch64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
+| **aarch64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | ppcle64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | ppc64 AIX | ⏸️         | ⏸️         | ⏸️              | ⛔               | ⛔            |       |
 | x32 Windows | ⏸️       | ⏸️         | ⏸️              | ⛔               | ⏸️             |       |
@@ -38,14 +38,14 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 | **x64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | **x64 Windows** | ⏸️   | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | **x64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
-| aarch64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
+| **aarch64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
+| **aarch64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
 | ppcle64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | s390x Linux   | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | ppc64 AIX | ⏸️         | ⏸️         | ⏸️              | ⛔               | ⛔            |       |
 | x32 Windows | ⏸️       | ⏸️         | ⏸️              | ⏸                | ⛔            |       |
 | arm32 Linux | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | x64 alpine-Linux | ⏸️  | ⏸️         | ⏸️              | ⏸️                | ⏸️             | This will be a headless build |
-| aarch64 Mac | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
 
 ### JDK17.0.XX+Y
 | Platforms | jdk17 AQA | jdk17 TCK | jdk17 published| jdk17 installers | jdk17 images | Notes |
@@ -53,14 +53,14 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 | **x64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
 | **x64 Windows** | ⏸️   | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
 | **x64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔           |       |
-| aarch64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
+| **aarch64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
+| **aarch64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔           |       |
 | ppcle64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
 | s390x Linux   | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
 | ppc64 AIX | ⏸️         | ⏸️         | ⏸️              | ⛔               | ⛔           |       |
 | x32 Windows | ⏸️       | ⏸️         | ⏸️              | ⏸                | ⛔           |       |
 | arm32 Linux | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⏸️            |       |
 | x64 alpine-Linux | ⏸️  | ⏸️         | ⏸️              | ⏸️                | ⏸️            | This will be a headless build |
-| aarch64 Mac | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔           |       |
 
 ### JDK20.0.XX+Y
 | Platform  | jdk20 AQA | jdk20 TCK | jdk20 published| jdk20 installers | jdk20 images  | Notes |
@@ -68,11 +68,11 @@ Sharing information in this issue since the TCK work is being tracked in temurin
 | **x64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | **x64 Windows** | ⏸️   | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | **x64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |
-| aarch64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
+| **aarch64 Linux** | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
+| **aarch64 Mac** | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔           |       |
 | ppcle64 Linux | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | s390x Linux   | ⏸️     | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | ppc64 AIX | ⏸️         | ⏸️         | ⏸️              | ⛔               | ⛔            |       |
 | x32 Windows | ⏸️       | ⏸️         | ⏸️              | ⏸                | ⛔            |       |
 | arm32 Linux | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⏸️             |       |
 | x64 alpine-Linux | ⏸️  | ⏸️         | ⏸️              | ⏸️                | ⏸️             | This will be a headless build |
-| aarch64 Mac | ⏸️       | ⏸️         | ⏸️              | ⏸️                | ⛔            |       |


### PR DESCRIPTION
Fixes https://github.com/adoptium/adoptium/issues/226

Move from 12 primary platforms to 19 (adding aarch64 Linux/OSX) as per the updated 2023 program plan.